### PR TITLE
Compute bottom constraint by expressing keyboard's frame in self.view co...

### DIFF
--- a/LHSKeyboardAdjusting/UIViewController+LHSKeyboardAdjustment.m
+++ b/LHSKeyboardAdjusting/UIViewController+LHSKeyboardAdjustment.m
@@ -57,8 +57,8 @@
         }
         
         CGRect frame = [sender.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-        CGRect newFrame = [self.view convertRect:frame fromView:[[UIApplication sharedApplication] delegate].window];
-        self.keyboardAdjustingBottomConstraint.constant = newFrame.origin.y - CGRectGetHeight(self.view.frame);
+        CGRect keyboardFrameInViewCoordinates = [self.view convertRect:frame fromView:nil];
+        self.keyboardAdjustingBottomConstraint.constant = CGRectGetHeight(self.view.bounds) - keyboardFrameInViewCoordinates.origin.y;
         [self.view layoutIfNeeded];
     }
 }


### PR DESCRIPTION
...ordinate space.  This addresses cases when self.view does not extend to the bottom of the window and continues to work when it does.