### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Note: LHSKeyboardAdjusting requires Auto Layout in your build target, so it will
 
 ### Installation
 
-LHSKeyboardAdjusting uses Cocoapods, so in your Podfile, just add something like this:
+LHSKeyboardAdjusting uses CocoaPods, so in your Podfile, just add something like this:
 
     pod 'LHSKeyboardAdjusting', '0.0.1'
 
 Then run `pod update` and you'll be ready to go.
 
-If you don't use Cocoapods, dragging and dropping the `LHSKeyboardAdjusting` folder into your Xcode project will do the trick as well.
+If you don't use CocoaPods, dragging and dropping the `LHSKeyboardAdjusting` folder into your Xcode project will do the trick as well.
 
 ### Usage
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
